### PR TITLE
Differentiate role and user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LATEST := ${NAME}:latest
 
 .PHONY: test
 test:
-		go test ./...
+		ENV="development" go test ./...
 
 .PHONY: dev
 dev:

--- a/handlers/domain.go
+++ b/handlers/domain.go
@@ -3,10 +3,11 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 
 	casbin "github.com/casbin/casbin/v2"
-	"github.com/gorilla/schema"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/schema"
 )
 
 type Domain struct {
@@ -66,7 +67,6 @@ func (h *DomainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			input.Parent = "root"
 		}
 		h.Enforcer.AddNamedGroupingPolicy("g2", input.Domain, input.Parent)
-		
 
 		if len(input.SubDomains) != 0 {
 			for _, subdomain := range input.SubDomains {
@@ -97,6 +97,9 @@ func (h *DomainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else if len(filter.Domain) != 0 {
 			h.Enforcer.RemoveFilteredNamedGroupingPolicy("g2", 0, filter.Domain)
 			h.Enforcer.RemoveFilteredNamedGroupingPolicy("g2", 1, filter.Domain)
+		}
+		if os.Getenv("ENV") != "development" {
+			h.Enforcer.SavePolicy()
 		}
 	}
 }

--- a/handlers/enforce.go
+++ b/handlers/enforce.go
@@ -9,18 +9,9 @@ import (
 	"github.com/gorilla/schema"
 )
 
-type EnforcesOutput struct {
-	Enforces []EnforceOutput `json:"enforces,omitempty"`
-}
+type EnforcesOutput []bool
 
-type EnforceOutput struct {
-	Enforce *EnforceInput `json:"enforce,omitempty"`
-	Permit  bool          `json:"permit"`
-}
-
-type EnforcesInput struct {
-	Enforces []EnforceInput `json:"enforces,omitempty"`
-}
+type EnforcesInput []EnforceInput
 
 type EnforceInput struct {
 	Domain  string `json:"domain,omitempty" schema:"domain,omitempty"`
@@ -52,13 +43,9 @@ func (h *EnforceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		var output EnforcesOutput
 
-		for _, enforce := range input.Enforces {
+		for _, enforce := range input {
 			permit, _ := h.Enforcer.Enforce(enforce.Domain, enforce.Subject, enforce.Object, enforce.Action)
-			enforced := EnforceOutput{
-				Enforce: &enforce,
-				Permit:  permit,
-			}
-			output.Enforces = append(output.Enforces, enforced)
+			output = append(output, permit)
 		}
 		js, _ := json.Marshal(output)
 		w.Write(js)

--- a/handlers/enforce_test.go
+++ b/handlers/enforce_test.go
@@ -105,7 +105,7 @@ func TestBatchEnforcePolicy(t *testing.T) {
 
 	enforces := EnforcesInput{}
 	for _, c := range cases {
-		enforces.Enforces = append(enforces.Enforces, c.Request)
+		enforces = append(enforces, c.Request)
 	}
 	body, _ := json.Marshal(enforces)
 
@@ -123,9 +123,9 @@ func TestBatchEnforcePolicy(t *testing.T) {
 	output := EnforcesOutput{}
 	json.NewDecoder(res.Body).Decode(&output)
 	for k, c := range cases {
-		if output.Enforces[k].Permit != c.ExpectPermit {
+		if output[k] != c.ExpectPermit {
 			t.Errorf("Expected the message '%s' for '%s'\n", strconv.FormatBool(c.ExpectPermit), fmt.Sprintf("case=%d-%s", k, c.Description))
-			t.Errorf("Received '%s'\n", strconv.FormatBool(output.Enforces[k].Permit))
+			t.Errorf("Received '%s'\n", strconv.FormatBool(output[k]))
 		}
 	}
 }

--- a/handlers/enforce_test.policy.csv
+++ b/handlers/enforce_test.policy.csv
@@ -1,5 +1,5 @@
-p, domain:hk, role:admin, form, write
-p, domain:asia, role:admin, form, delete
+p, domain:hk, role:admin, form, write, allow
+p, domain:asia, role:admin, form, delete, allow
 
 g, alice, role:admin, domain:asia
 g, billy, role:admin, domain:hk

--- a/handlers/policy.go
+++ b/handlers/policy.go
@@ -120,6 +120,7 @@ func (h *PolicyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		w.WriteHeader(200)
+		h.Enforcer.SavePolicy()
 	case http.MethodDelete:
 		decoder := schema.NewDecoder()
 		filter := Policy{}
@@ -138,5 +139,6 @@ func (h *PolicyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		h.Enforcer.RemovePolicy(filter.ToArgs()...)
+		h.Enforcer.SavePolicy()
 	}
 }

--- a/handlers/role.go
+++ b/handlers/role.go
@@ -120,6 +120,7 @@ func (h *RoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				roleAssignments = append(roleAssignments, assignment)
 			}
 		}
+		h.Enforcer.SavePolicy()
 
 		js, _ := json.Marshal(roleAssignments)
 		w.Write(js)
@@ -149,5 +150,7 @@ func (h *RoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if filter.Subject == NoSubject {
 			h.Enforcer.AddNamedGroupingPolicy("g4", filter.Subject, "disabled", filter.Domain)
 		}
+
+		h.Enforcer.SavePolicy()
 	}
 }

--- a/handlers/role_test.policy.csv
+++ b/handlers/role_test.policy.csv
@@ -10,5 +10,5 @@ g2, domain:hk, alice
 g2, domain:hk, domain:asia
 g2, domain:asia, domain:world
 
-g3, alice, user
-g3, role:admin, role
+g3, admin, role, domain:hk
+g3, role:admin, role, domain:asia

--- a/handlers/role_test.policy.csv
+++ b/handlers/role_test.policy.csv
@@ -1,14 +1,9 @@
 p, role:admin, root, form, read
-
 g, alice, role:admin, domain:asia
-
 g, role:admin, role:intern, domain:asia
-
 g2, domain:asia, alice
 g2, domain:hk, alice
-
 g2, domain:hk, domain:asia
 g2, domain:asia, domain:world
-
 g3, admin, role, domain:hk
 g3, role:admin, role, domain:asia

--- a/handlers/subject.go
+++ b/handlers/subject.go
@@ -63,6 +63,7 @@ func (h *SubjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		groups := filters.Choose(GroupsFromCasbin(raw), func(g Group) bool {
 			return ((len(filter.Domain) == 0 || filter.Domain == g.Domain) &&
 				(len(filter.Role) == 0 || filter.Role == g.Role) &&
+				(g.Subject != NoSubject) &&
 				(!h.Enforcer.HasNamedGroupingPolicy("g3", g.Subject, "role") || h.Enforcer.HasNamedGroupingPolicy("g3", g.Subject, "user")))
 		})
 		var subjects []string

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -10,42 +10,23 @@ import (
 	filters "robpike.io/filter"
 )
 
-type Group struct {
-	Subject string `json:"subject,omitempty" schema:"subject,omitempty"`
-	Domain  string `json:"domain,omitempty" schema:"domain,omitempty"`
-	Role    string `json:"role,omitempty" schema:"role,omitempty"`
-}
-
-func GroupsFromCasbin(raw [][]string) []Group {
-	ss := []Group{}
-
-	for _, s := range raw {
-		ss = append(ss, Group{
-			Subject: s[0],
-			Role:    s[1],
-			Domain:  s[2],
-		})
-	}
-	return ss
-}
-
-type SubjectFilter struct {
+type UserFilter struct {
 	Domain string `json:"domain,omitempty" schema:"domain,omitempty"`
 	Role   string `json:"role,omitempty" schema:"role,omitempty"`
 }
 
-type SubjectHandler struct {
+type UserHandler struct {
 	Enforcer *casbin.Enforcer
 }
 
-func (h *SubjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	domain := mux.Vars(r)["domain"]
 	role := mux.Vars(r)["role"]
 
 	switch r.Method {
 	case http.MethodGet:
 		decoder := schema.NewDecoder()
-		filter := SubjectFilter{}
+		filter := UserFilter{}
 		err := decoder.Decode(&filter, r.URL.Query())
 		if err != nil {
 			panic(err)
@@ -63,13 +44,14 @@ func (h *SubjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		groups := filters.Choose(GroupsFromCasbin(raw), func(g Group) bool {
 			return ((len(filter.Domain) == 0 || filter.Domain == g.Domain) &&
 				(len(filter.Role) == 0 || filter.Role == g.Role) &&
-				(g.Subject != NoSubject))
+				(g.Subject != NoSubject) &&
+				(!h.Enforcer.HasNamedGroupingPolicy("g3", g.Subject, "role", g.Domain) || h.Enforcer.HasNamedGroupingPolicy("g3", g.Subject, "user", g.Domain)))
 		})
-		var subjects []string
+		var Users []string
 		for _, group := range groups.([]Group) {
-			subjects = append(subjects, group.Subject)
+			Users = append(Users, group.Subject)
 		}
-		js, _ := json.Marshal(subjects)
+		js, _ := json.Marshal(Users)
 		w.Write(js)
 	}
 }

--- a/handlers/user_test.go
+++ b/handlers/user_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/casbin/casbin/v2"
 )
 
-func TestGetSubjects(t *testing.T) {
+func TestGetUsers(t *testing.T) {
 	e, _ := casbin.NewEnforcer("../model.conf", "./role_test.policy.csv")
 
-	handler := &SubjectHandler{e}
+	handler := &UserHandler{e}
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -28,7 +28,7 @@ func TestGetSubjects(t *testing.T) {
 	if res.StatusCode != 200 {
 		t.Fatalf("Received non-200 response: %d\n", res.StatusCode)
 	}
-	policy, _ := json.Marshal([]string{"alice", "role:admin"})
+	policy, _ := json.Marshal([]string{"alice"})
 	expected := string(policy)
 	actual, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	r.Handle("/{domain}/subject/{subject}/role", &handlers.RoleHandler{Enforcer: e})
 	r.Handle("/{domain}/role/{role}/policy", &handlers.PolicyHandler{Enforcer: e})
 	r.Handle("/{domain}/role/{role}/subject", &handlers.SubjectHandler{Enforcer: e})
+	r.Handle("/{domain}/role/{role}/user", &handlers.UserHandler{Enforcer: e})
 	r.Handle("/{domain}/role", &handlers.RoleHandler{Enforcer: e})
 	r.Handle("/{domain}/policy", &handlers.PolicyHandler{Enforcer: e})
 	r.Handle("/{domain}", &handlers.DomainHandler{Enforcer: e})

--- a/model.conf
+++ b/model.conf
@@ -2,7 +2,7 @@
 r = domain, sub, obj, act
 
 [policy_definition]
-p = domain, sub, obj, act
+p = domain, sub, obj, act, eft
 
 [role_definition]
 g = _, _, _
@@ -14,4 +14,4 @@ g4 = _, _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub, r.domain) && r.act == p.act && (g2(p.domain, r.sub) || g2('root', r.sub)) && !g4(r.sub, 'disabled') && !g4(p.sub, 'disabled') && r.domain == p.domain
+m = (g(r.sub, p.sub, r.domain) || g3(r.sub, 'role', r.domain)) && r.act == p.act && (g2(p.domain, r.sub) || g2('root', r.sub) || g3(r.sub, 'role', r.domain)) && !g4(r.sub, 'disabled') && !g4(p.sub, 'disabled') && r.domain == p.domain

--- a/model.conf
+++ b/model.conf
@@ -14,4 +14,4 @@ g4 = _, _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = (g(r.sub, p.sub, r.domain) || g3(r.sub, 'role', r.domain)) && r.act == p.act && (g2(p.domain, r.sub) || g2('root', r.sub) || g3(r.sub, 'role', r.domain)) && !g4(r.sub, 'disabled') && !g4(p.sub, 'disabled') && r.domain == p.domain
+m = (g(r.sub, p.sub, r.domain) || r.sub == p.sub) && r.act == p.act && (g2(p.domain, r.sub) || g2('root', r.sub) || r.sub == p.sub) && !g4(r.sub, 'disabled') && !g4(p.sub, 'disabled') && r.domain == p.domain

--- a/model.conf
+++ b/model.conf
@@ -7,10 +7,11 @@ p = domain, sub, obj, act
 [role_definition]
 g = _, _, _
 g2 = _, _
-g3 = _, _
+g3 = _, _, _
+g4 = _, _, _
 
 [policy_effect]
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub, r.domain) && r.act == p.act && (g2(p.domain, r.sub) || g2('root', r.sub)) && r.domain == p.domain
+m = g(r.sub, p.sub, r.domain) && r.act == p.act && (g2(p.domain, r.sub) || g2('root', r.sub)) && !g4(r.sub, 'disabled') && !g4(p.sub, 'disabled') && r.domain == p.domain


### PR DESCRIPTION
refs: oursky/skygear-rbac#17 

Since we need to differentiate user and role even in generic cases:

- [x] Add role to role group with `/{domain}/role`
- [x] Add handler to list users with `/{domain}/role/{id}/user` (o i already implemented it..)
- [x] Add condition to disallow assigning role to subject in urls like `/{domain}/subject/{id}/role/` if role is not registered in `/{domain}/role`