### PR TITLE
feat: Adds full reload handler on POST

### DIFF
--- a/handlers/reload.go
+++ b/handlers/reload.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	casbin "github.com/casbin/casbin/v2"
+
+	"skygear-rbac/constants"
+)
+
+type ReloadHandler struct {
+	Enforcer *casbin.Enforcer
+}
+
+type ReloadInput struct {
+	Domains         []DomainInput        `json:"domains,omitempty" schema:"domains,omitempty"`
+	RoleAssignments RoleAssignmentsInput `json:"roleAssignments,omitempty" schema:"roleAssignments,omitempty"`
+	Policies        PoliciesInput        `json:"policies,omitempty" schema:"policies,omitempty"`
+}
+
+func (h *ReloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		err := h.Enforcer.LoadPolicy()
+		if err != nil {
+			log.Fatal(err)
+			w.WriteHeader(502)
+		}
+		log.Println("♻ RBAC reloaded enforcer")
+	case http.MethodPost:
+		var err error
+
+		input := ReloadInput{}
+		json.NewDecoder(r.Body).Decode(&input)
+
+		h.Enforcer.LoadPolicy()
+
+		// Saves domain inheritance
+		for _, domainInput := range input.Domains {
+			if len(domainInput.Parent) == 0 {
+				domainInput.Parent = "root"
+			}
+
+			_, err = h.Enforcer.AddNamedGroupingPolicy("g", domainInput.Parent, domainInput.Domain, constants.IsDomain)
+
+			if err != nil {
+				log.Fatal(err)
+				w.WriteHeader(502)
+			}
+
+			if len(domainInput.SubDomains) != 0 {
+				for _, subdomain := range domainInput.SubDomains {
+					_, err = h.Enforcer.AddNamedGroupingPolicy("g", domainInput.Domain, subdomain, constants.IsDomain)
+					if err != nil {
+						log.Fatal(err)
+						w.WriteHeader(502)
+					}
+				}
+			}
+		}
+
+		// Saves role assignment
+		for _, roleAssignmentInput := range input.RoleAssignments {
+			if len(roleAssignmentInput.Subject) == 0 {
+				roleAssignmentInput.Subject = constants.NoSubject
+			}
+
+			if roleAssignmentInput.Unassign {
+				_, err = h.Enforcer.RemoveNamedGroupingPolicy("g", roleAssignmentInput.Subject, roleAssignmentInput.Role, roleAssignmentInput.Domain)
+				if err != nil {
+					log.Fatal(err)
+					w.WriteHeader(502)
+				}
+			} else {
+				_, err = h.Enforcer.AddNamedGroupingPolicy("g", roleAssignmentInput.Subject, roleAssignmentInput.Role, roleAssignmentInput.Domain)
+				if err != nil {
+					log.Fatal(err)
+					w.WriteHeader(502)
+				}
+			}
+		}
+
+		// Saves access rights
+		for _, policyInput := range input.Policies {
+			if policyInput.Effect == "deny" {
+				_, err = h.Enforcer.AddPolicy(policyInput.Domain, policyInput.Subject, policyInput.Object, policyInput.Action, "deny")
+				if err != nil {
+					log.Fatal(err)
+					w.WriteHeader(502)
+				}
+			} else {
+				_, err := h.Enforcer.AddPolicy(policyInput.Domain, policyInput.Subject, policyInput.Object, policyInput.Action, "allow")
+				if err != nil {
+					log.Fatal(err)
+					w.WriteHeader(502)
+				}
+			}
+		}
+
+		h.Enforcer.SavePolicy()
+	}
+}

--- a/handlers/reload_test.go
+++ b/handlers/reload_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"skygear-rbac/constants"
+	enforcer "skygear-rbac/enforcer"
+	"testing"
+)
+
+func TestReload(t *testing.T) {
+	e, _ := enforcer.NewEnforcer(enforcer.Config{
+		Model: "../model.conf",
+	})
+
+	handler := &ReloadHandler{e}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	fakeReloadInput := ReloadInput{
+		Domains: []DomainInput{
+			DomainInput{
+				Domain:     "domain:asia",
+				SubDomains: []string{"domain:hk", "domain:india"},
+			},
+		},
+		Policies: PoliciesInput{
+			PolicyInput{
+				Subject: "role:admin",
+				Object:  "book",
+				Action:  "read",
+				Domain:  "domain:hk",
+			},
+		},
+		RoleAssignments: RoleAssignmentsInput{
+			RoleAssignmentInput{
+				Role:    "role:admin",
+				Subject: "user:idiot",
+				Domain:  "domain:asia",
+			},
+		},
+	}
+
+	body, _ := json.Marshal(fakeReloadInput)
+
+	req, _ := http.NewRequest("POST", server.URL, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	res := rec.Result()
+
+	if res.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", res.StatusCode)
+	}
+
+	if !e.HasNamedGroupingPolicy("g", "domain:asia", "domain:india", constants.IsDomain) {
+		t.Error("Expected domain:asia to have subdomain domain:india\n")
+	}
+
+	if !e.HasNamedGroupingPolicy("g", "user:idiot", "role:admin", "domain:asia") {
+		t.Error("Expected user:idiot to be assigned role:admin in domain:asia\n")
+	}
+
+	allowed, _ := e.Enforce("domain:hk", "role:admin", "book", "read")
+
+	if !allowed {
+		t.Error("Expected role:admin to be allowed to write book in domain:hk\n")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -43,14 +43,7 @@ func main() {
 		fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
 	})
 	// For reloading policy / model if it is updated externally e.g. Directly updated rules in database
-	r.HandleFunc("/reload", func(w http.ResponseWriter, r *http.Request) {
-		err := reloadEnforcer(enforcer)
-		if err != nil {
-			log.Fatal(err)
-			w.WriteHeader(502)
-		}
-		log.Println("♻ RBAC reloaded enforcer")
-	})
+	r.Handle("/reload", &handlers.ReloadHandler{Enforcer: enforcer})
 	r.Handle("/enforce", &handlers.EnforceHandler{Enforcer: enforcer})
 	r.Handle("/{domain}/subject/{subject}/role", &handlers.RoleHandler{Enforcer: enforcer})
 	r.Handle("/{domain}/role/{role}/policy", &handlers.PolicyHandler{Enforcer: enforcer})


### PR DESCRIPTION
Allows RBAC to be fully synced if not using persisted storage i.e. In-Memory

NOTE: For other storage methods the storage must be cleared before reloading, otherwise merged data might be unreliable 